### PR TITLE
fix: improve validation of awg headers (h1-h4)

### DIFF
--- a/addon/amneziawg.sh
+++ b/addon/amneziawg.sh
@@ -598,6 +598,11 @@ validate_uint(){
     return 0
 }
 
+validate_header(){
+    echo "$1" | grep -qE '^[0-9-]+$' || return 1
+    return 0
+}
+
 validate_ip(){
     echo "$1" | grep -qE '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$' || return 1
     return 0
@@ -655,10 +660,10 @@ generate_config(){
     [ -n "$jmax" ] && { validate_uint "$jmax" || { log_msg "ERROR: Invalid Jmax: $jmax"; return 1; }; }
     [ -n "$s1" ] && { validate_uint "$s1" || { log_msg "ERROR: Invalid S1: $s1"; return 1; }; }
     [ -n "$s2" ] && { validate_uint "$s2" || { log_msg "ERROR: Invalid S2: $s2"; return 1; }; }
-    [ -n "$h1" ] && { validate_uint "$h1" || { log_msg "ERROR: Invalid H1: $h1"; return 1; }; }
-    [ -n "$h2" ] && { validate_uint "$h2" || { log_msg "ERROR: Invalid H2: $h2"; return 1; }; }
-    [ -n "$h3" ] && { validate_uint "$h3" || { log_msg "ERROR: Invalid H3: $h3"; return 1; }; }
-    [ -n "$h4" ] && { validate_uint "$h4" || { log_msg "ERROR: Invalid H4: $h4"; return 1; }; }
+    [ -n "$h1" ] && { validate_header "$h1" || { log_msg "ERROR: Invalid H1: $h1"; return 1; }; }
+    [ -n "$h2" ] && { validate_header "$h2" || { log_msg "ERROR: Invalid H2: $h2"; return 1; }; }
+    [ -n "$h3" ] && { validate_header "$h3" || { log_msg "ERROR: Invalid H3: $h3"; return 1; }; }
+    [ -n "$h4" ] && { validate_header "$h4" || { log_msg "ERROR: Invalid H4: $h4"; return 1; }; }
 
     {
         echo "[Interface]"


### PR DESCRIPTION
AWG headings (H1-H4) may contain a dash.

<img width="246" height="85" alt="h1-4" src="https://github.com/user-attachments/assets/0cec51cd-b4bf-4ce3-a0fd-bcefc57028b0" />
