### PR TITLE
Add direct destination exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ VPN-клиент с обходом DPI-блокировок на базе [Amnez
 - **Маршрутизация по устройствам** -- политика VPN для каждого устройства: `VPN All`, `VPN Geo`, `Direct`
 - **GeoIP по сервисам** -- IP-диапазоны Telegram, Google, Netflix, Twitter и др. через [Loyalsoldier/geoip](https://github.com/Loyalsoldier/geoip)
 - **GeoSite по доменам** -- списки доменов через [v2fly/domain-list-community](https://github.com/v2fly/domain-list-community) + dnsmasq ipset
+- **Direct-исключения** -- обход VPN для выбранных доменов и IPv4/CIDR-диапазонов
 - **Свои домены и IP** -- ручное добавление доменов и CIDR-подсетей
 - **Перехват DNS** -- принудительный DNS через dnsmasq, блокировка DoH/DoT для надёжной гео-маршрутизации
 - **MSS clamping** -- автоматическое исправление TCP MSS для туннельного трафика
@@ -134,6 +135,15 @@ youtube,google,discord,netflix,spotify,instagram
 
 - **Custom Domains** -- домены через запятую (например `example.com,service.org`)
 - **Custom IPs** -- IP/CIDR через запятую (например `8.8.8.8,1.1.1.0/24`)
+
+### Direct-исключения
+
+Используйте **Direct Domains** и **Direct IPs / Subnets**, чтобы выбранные destination-адреса шли напрямую через WAN, а основная политика оставалась `VPN All`.
+
+- Direct-домены резолвятся через dnsmasq и добавляются в ipset `awg_direct`.
+- Direct IPv4-адреса и CIDR-диапазоны загружаются в `awg_direct` напрямую.
+- `awg_direct` проверяется до правил маршрутизации устройств и до общего VPN-mark.
+- Для доменных direct-исключений клиенты должны использовать роутер как DNS. IPv6-исключения не применяются, пока активна защита от IPv6 leak.
 
 ## Сборка из исходников
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -35,6 +35,7 @@ Other aarch64 Merlin routers should also work.
 - **Per-device routing** -- assign VPN policy per device: `VPN All`, `VPN Geo`, `Direct`
 - **GeoIP service routing** -- IP ranges for Telegram, Google, Netflix, Twitter, etc. via [Loyalsoldier/geoip](https://github.com/Loyalsoldier/geoip)
 - **GeoSite domain routing** -- domain lists via [v2fly/domain-list-community](https://github.com/v2fly/domain-list-community) + dnsmasq ipset
+- **Direct exceptions** -- bypass VPN for selected destination domains and IPv4/CIDR ranges
 - **Custom domains & IPs** -- manual domain and CIDR entries
 - **DNS interception** -- forces DNS through dnsmasq, blocks DoH/DoT for reliable geo routing
 - **MSS clamping** -- automatic TCP MSS fix for tunnel traffic
@@ -128,6 +129,15 @@ Requires devices to use the router as DNS server. For iPhones: **Settings > Wi-F
 
 - **Custom Domains** -- comma-separated domains (e.g. `example.com,service.org`)
 - **Custom IPs** -- comma-separated IPs/CIDRs (e.g. `8.8.8.8,1.1.1.0/24`)
+
+### Direct Exceptions
+
+Use **Direct Domains** and **Direct IPs / Subnets** to bypass VPN for selected destinations while keeping the default policy as `VPN All`.
+
+- Direct domains are resolved by dnsmasq and added to the `awg_direct` ipset.
+- Direct IPv4 addresses and CIDR ranges are loaded into `awg_direct` directly.
+- The direct ipset is evaluated before per-device and default VPN marking rules.
+- Domain-based direct exceptions require clients to use the router as DNS. IPv6 direct exceptions are not applied while IPv6 leak protection is active.
 
 ## Building from source
 

--- a/addon/amneziawg.sh
+++ b/addon/amneziawg.sh
@@ -16,8 +16,10 @@ SETTINGS="/jffs/addons/custom_settings.txt"
 CLIENTS_FILE="$AWG_DIR/clients.list"
 GEO_DIR="$AWG_DIR/geo"
 IPSET_NAME="awg_dst"
+DIRECT_IPSET_NAME="awg_direct"
 FWMARK="0x100"
 DNSMASQ_AWG_CONF="$AWG_DIR/dnsmasq_awg.conf"
+DNSMASQ_DIRECT_CONF="$AWG_DIR/dnsmasq_awg_direct.conf"
 DNSMASQ_INCLUDE="/jffs/configs/dnsmasq.conf.add"
 SCRIPT_NAME="amneziawg"
 RT_TABLE=300
@@ -247,6 +249,88 @@ ipset_load_file(){
     ' "$file" | ipset restore -! 2>/dev/null
 }
 
+count_list_items(){
+    echo "$1" | tr ',' '\n' | awk '
+        {
+            gsub(/[ \t\r]/, "")
+            if($0 != "" && $0 !~ /^#/) count++
+        }
+        END{print count + 0}
+    '
+}
+
+load_direct_exceptions(){
+    local direct_ips direct_domains cidr domain
+    direct_ips=$(get_setting awg_direct_custom_ips)
+    direct_domains=$(get_setting awg_direct_custom_domains)
+    if [ "$(count_list_items "$direct_ips")" -eq 0 ] && [ "$(count_list_items "$direct_domains")" -eq 0 ]; then
+        rm -f "$DNSMASQ_DIRECT_CONF"
+        return 1
+    fi
+
+    ipset create "$DIRECT_IPSET_NAME" hash:net family inet hashsize 4096 maxelem 65536 2>/dev/null || \
+        ipset flush "$DIRECT_IPSET_NAME" 2>/dev/null
+    if ! ipset list "$DIRECT_IPSET_NAME" >/dev/null 2>&1; then
+        log_msg "WARNING: direct exceptions disabled, ipset $DIRECT_IPSET_NAME creation failed"
+        return 1
+    fi
+
+    if [ -n "$direct_ips" ]; then
+        echo "$direct_ips" | tr ',' '\n' | while read -r cidr; do
+            cidr=$(echo "$cidr" | tr -d ' \r')
+            [ -z "$cidr" ] && continue
+            echo "$cidr" | grep -q ':' && continue
+            ipset add "$DIRECT_IPSET_NAME" "$cidr" 2>/dev/null
+        done
+    fi
+
+    echo "# AmneziaWG direct exception routing - auto-generated" > "$DNSMASQ_DIRECT_CONF"
+    if [ -n "$direct_domains" ]; then
+        local chunk_line="ipset=/"
+        local chunk_count=0
+        local direct_domain_file="/tmp/.awg_direct_domains"
+        echo "$direct_domains" | tr ',' '\n' > "$direct_domain_file"
+        while read -r domain; do
+            domain=$(echo "$domain" | tr -d ' \r')
+            [ -z "$domain" ] && continue
+            echo "$domain" | grep -q '^#' && continue
+            domain=$(echo "$domain" | sed 's/^\.//;s/:@[^ ]*$//')
+            echo "$domain" | grep -q '[^a-zA-Z0-9._-]' && continue
+            chunk_line="${chunk_line}${domain}/"
+            chunk_count=$((chunk_count + 1))
+            if [ $chunk_count -ge 20 ]; then
+                echo "${chunk_line}${DIRECT_IPSET_NAME}" >> "$DNSMASQ_DIRECT_CONF"
+                chunk_line="ipset=/"
+                chunk_count=0
+            fi
+        done < "$direct_domain_file"
+        rm -f "$direct_domain_file"
+        [ $chunk_count -gt 0 ] && echo "${chunk_line}${DIRECT_IPSET_NAME}" >> "$DNSMASQ_DIRECT_CONF"
+    fi
+
+    if [ "$(count_list_items "$direct_domains")" -gt 0 ]; then
+        mkdir -p "$(dirname "$DNSMASQ_INCLUDE")"
+        if ! grep -qF "conf-file=$DNSMASQ_DIRECT_CONF" "$DNSMASQ_INCLUDE" 2>/dev/null; then
+            echo "conf-file=$DNSMASQ_DIRECT_CONF" >> "$DNSMASQ_INCLUDE"
+        fi
+    fi
+
+    return 0
+}
+
+pre_resolve_dnsmasq_ipsets(){
+    local conf="$1"
+    [ -f "$conf" ] || return 0
+    local bg_count=0
+    awk -F/ '/^ipset=/{for(i=2;i<NF;i++)print $i}' "$conf" | while read -r domain; do
+        [ -z "$domain" ] && continue
+        nslookup "$domain" 127.0.0.1 >/dev/null 2>&1 &
+        bg_count=$((bg_count + 1))
+        [ $bg_count -ge 10 ] && { wait; bg_count=0; }
+    done
+    wait
+}
+
 # --- Unified firewall setup ---
 
 setup_dns_interception(){
@@ -304,10 +388,14 @@ cleanup_firewall(){
     # Destroy ipset
     ipset flush "$IPSET_NAME" 2>/dev/null
     ipset destroy "$IPSET_NAME" 2>/dev/null
+    ipset flush "$DIRECT_IPSET_NAME" 2>/dev/null
+    ipset destroy "$DIRECT_IPSET_NAME" 2>/dev/null
 
     # Remove dnsmasq config
     rm -f "$DNSMASQ_AWG_CONF"
+    rm -f "$DNSMASQ_DIRECT_CONF"
     [ -f "$DNSMASQ_INCLUDE" ] && sed -i "\|${DNSMASQ_AWG_CONF}|d" "$DNSMASQ_INCLUDE"
+    [ -f "$DNSMASQ_INCLUDE" ] && sed -i "\|${DNSMASQ_DIRECT_CONF}|d" "$DNSMASQ_INCLUDE"
 
     # Remove cron
     cru d awg_geo_update 2>/dev/null
@@ -324,12 +412,18 @@ setup_firewall(){
     local default_policy=$(get_setting awg_default_policy)
     [ -z "$default_policy" ] && default_policy="direct"
     local has_geo=false
+    local direct_domains=$(get_setting awg_direct_custom_domains)
+    local direct_domain_count=$(count_list_items "$direct_domains")
+    local direct_ipset_ready=false
 
     # --- Create ipset ---
     ipset create "$IPSET_NAME" hash:net family inet hashsize 4096 maxelem 131072 timeout 86400 2>/dev/null
     if ! ipset list "$IPSET_NAME" >/dev/null 2>&1; then
         log_msg "ERROR: ipset $IPSET_NAME creation failed, geo routing disabled"
         has_geo=false
+    fi
+    if load_direct_exceptions; then
+        direct_ipset_ready=true
     fi
 
     # --- Load GeoIP subnets into ipset (bulk) ---
@@ -423,6 +517,10 @@ setup_firewall(){
     iptables -t mangle -A "$AWG_CHAIN" -p udp -m multiport --dports 67,68,123 -j RETURN
     iptables -t mangle -A "$AWG_CHAIN" -d 224.0.0.0/4 -j RETURN
     [ -n "$endpoint" ] && iptables -t mangle -A "$AWG_CHAIN" -d "$endpoint" -j RETURN
+    if [ "$direct_ipset_ready" = true ]; then
+        iptables -t mangle -A "$AWG_CHAIN" -m set --match-set "$DIRECT_IPSET_NAME" dst -j RETURN
+        log_msg "Direct exceptions enabled"
+    fi
 
     # --- Per-device rules (two passes for correct ordering) ---
     save_clients
@@ -517,20 +615,12 @@ setup_firewall(){
     fi
 
     # --- Restart dnsmasq if geo active ---
-    if [ $domain_count -gt 0 ] || [ "$has_geo" = true ]; then
+    if [ $domain_count -gt 0 ] || [ $direct_domain_count -gt 0 ] || [ "$has_geo" = true ]; then
         service restart_dnsmasq >/dev/null 2>&1
         wait_for_dns 10
         # Pre-resolve domains to populate ipset
-        if [ -f "$DNSMASQ_AWG_CONF" ]; then
-            local bg_count=0
-            awk -F/ '/^ipset=/{for(i=2;i<NF;i++)print $i}' "$DNSMASQ_AWG_CONF" | while read -r domain; do
-                [ -z "$domain" ] && continue
-                nslookup "$domain" 127.0.0.1 >/dev/null 2>&1 &
-                bg_count=$((bg_count + 1))
-                [ $bg_count -ge 10 ] && { wait; bg_count=0; }
-            done
-            wait
-        fi
+        pre_resolve_dnsmasq_ipsets "$DNSMASQ_AWG_CONF"
+        pre_resolve_dnsmasq_ipsets "$DNSMASQ_DIRECT_CONF"
     fi
 
     # --- Always flush conntrack so devices reconnect through VPN ---
@@ -541,7 +631,10 @@ setup_firewall(){
         cru a awg_geo_update "0 4 * * * '$ADDON_DIR/amneziawg.sh' update_geo"
     fi
 
-    log_msg "Firewall configured: $ip_count IPs, $domain_count domains"
+    local direct_ip_count=0
+    ipset list "$DIRECT_IPSET_NAME" -t 2>/dev/null | grep -q "Number of entries" && \
+        direct_ip_count=$(ipset list "$DIRECT_IPSET_NAME" -t 2>/dev/null | awk '/Number of entries/{print $NF}')
+    log_msg "Firewall configured: $ip_count VPN IPs, $domain_count VPN domains, $direct_ip_count direct IPs, $direct_domain_count direct domains"
 }
 
 save_clients(){
@@ -925,11 +1018,18 @@ EOF
     [ -f "$DNSMASQ_AWG_CONF" ] && geo_domains=$(grep -c "^ipset=" "$DNSMASQ_AWG_CONF" 2>/dev/null)
     [ -z "$geo_domains" ] && geo_domains=0
 
+    local direct_ipset_count=0
+    ipset list "$DIRECT_IPSET_NAME" -t 2>/dev/null | grep -q "Number of entries" && \
+        direct_ipset_count=$(ipset list "$DIRECT_IPSET_NAME" -t 2>/dev/null | awk '/Number of entries/{print $NF}')
+
+    local direct_domains=0
+    direct_domains=$(count_list_items "$(get_setting awg_direct_custom_domains)")
+
     local geo_downloaded=false
     geo_available && geo_downloaded=true
 
     cat > "$STATUS_FILE" << STATUSEOF
-{"running":${running},"version":"${AWG_VERSION}","public_key":"${pub_key}","listen_port":"${listen_port}","interface_addr":"${iface_addr}","peers":${peers_json},"default_policy":"${default_policy}","clients":"${clients_data}","active_rules":${active_rules},"ipset_count":${ipset_count},"geo_domains":${geo_domains},"geo_downloaded":${geo_downloaded},"log":"${log_text}"}
+{"running":${running},"version":"${AWG_VERSION}","public_key":"${pub_key}","listen_port":"${listen_port}","interface_addr":"${iface_addr}","peers":${peers_json},"default_policy":"${default_policy}","clients":"${clients_data}","active_rules":${active_rules},"ipset_count":${ipset_count},"geo_domains":${geo_domains},"direct_ipset_count":${direct_ipset_count},"direct_domains":${direct_domains},"geo_downloaded":${geo_downloaded},"log":"${log_text}"}
 STATUSEOF
 }
 

--- a/addon/amneziawg_page.asp
+++ b/addon/amneziawg_page.asp
@@ -101,6 +101,12 @@
     font-family:monospace;
     font-size:12px;
 }
+.awg-help {
+    color:#B8C7C8;
+    font-size:11px;
+    margin-top:4px;
+    line-height:1.35;
+}
 </style>
 <script>
 var custom_settings = <% get_custom_settings(); %>;
@@ -276,6 +282,10 @@ function saveSettings(){
             if(fields[i] === 'awg_peer_allowedips' || fields[i] === 'awg_address' || fields[i] === 'awg_dns'){
                 v = v.replace(/\s+/g, '');
             }
+            if((fields[i] === 'awg_privatekey' || fields[i] === 'awg_peer_pubkey' || fields[i] === 'awg_peer_endpoint') &&
+               !v && custom_settings[fields[i]]){
+                continue;
+            }
             custom_settings[fields[i]] = v;
         }
     }
@@ -301,9 +311,9 @@ function saveSettings(){
     custom_settings.awg_geo_autoupdate = document.getElementById('geo_autoupdate').checked ? '1' : '0';
 
     // Basic validation
-    var pk = document.getElementById('awg_privatekey').value;
-    var pubk = document.getElementById('awg_peer_pubkey').value;
-    var ep = document.getElementById('awg_peer_endpoint').value;
+    var pk = (custom_settings.awg_privatekey || '').trim();
+    var pubk = (custom_settings.awg_peer_pubkey || '').trim();
+    var ep = (custom_settings.awg_peer_endpoint || '').trim();
     if(!pk || !pubk || !ep){
         alert('Required: Private Key, Peer Public Key, and Endpoint.');
         return;
@@ -1124,7 +1134,7 @@ function initAutocompleteIp(){
                         <input type="text" class="input_32_table" id="awg_geo_v2fly_ip" style="width:95%;" maxlength="512"
                             placeholder="telegram,google,facebook,twitter,netflix,cloudflare">
                         <br><span style="color:#888; font-size:11px;">Comma-separated. IP ranges for services: telegram, google, facebook, twitter, netflix, cloudflare, apple, amazon, microsoft, github, stripe, openai ...</span>
-                        <div style="color:#666; font-size:11px; margin-top:3px;">Works without DNS — direct IP matching. Ideal for Telegram, messengers, etc.</div>
+                        <div class="awg-help">Works without DNS — direct IP matching. Ideal for Telegram, messengers, etc.</div>
                     </td>
                 </tr>
                 </table>
@@ -1144,7 +1154,7 @@ function initAutocompleteIp(){
                     <td>
                         <input type="text" class="input_32_table" id="geo_custom_domains" style="width:95%;"
                                maxlength="2000" placeholder="example.com,another.org,service.net">
-                        <div style="color:#666; font-size:11px; margin-top:3px;">Comma-separated. DNS-resolved → routed through VPN</div>
+                        <div class="awg-help">Comma-separated. DNS-resolved → routed through VPN</div>
                     </td>
                 </tr>
                 <tr>
@@ -1152,7 +1162,7 @@ function initAutocompleteIp(){
                     <td>
                         <input type="text" class="input_32_table" id="geo_custom_ips" style="width:95%;"
                                maxlength="2000" placeholder="8.8.8.8,1.1.1.0/24,203.0.113.0/24">
-                        <div style="color:#666; font-size:11px; margin-top:3px;">Comma-separated IPs or CIDR subnets</div>
+                        <div class="awg-help">Comma-separated IPs or CIDR subnets</div>
                     </td>
                 </tr>
                 <tr>
@@ -1176,7 +1186,7 @@ function initAutocompleteIp(){
                     <td>
                         <textarea class="input_32_table awg-textarea" id="direct_custom_domains"
                                   placeholder="example.com&#10;another.org"></textarea>
-                        <div style="color:#666; font-size:11px; margin-top:3px;">One per line or comma-separated. DNS results are added to a direct ipset and bypass VPN.</div>
+                        <div class="awg-help">One per line or comma-separated. DNS results are added to a direct ipset and bypass VPN.</div>
                     </td>
                 </tr>
                 <tr>
@@ -1184,7 +1194,7 @@ function initAutocompleteIp(){
                     <td>
                         <textarea class="input_32_table awg-textarea" id="direct_custom_ips"
                                   placeholder="203.0.113.10/32&#10;198.51.100.0/24"></textarea>
-                        <div style="color:#666; font-size:11px; margin-top:3px;">IPv4 addresses or CIDR ranges that should use WAN directly before VPN routing rules are evaluated.</div>
+                        <div class="awg-help">IPv4 addresses or CIDR ranges that should use WAN directly before VPN routing rules are evaluated.</div>
                     </td>
                 </tr>
                 </table>

--- a/addon/amneziawg_page.asp
+++ b/addon/amneziawg_page.asp
@@ -94,6 +94,13 @@
 .awg-ac-list div:hover, .awg-ac-list div.selected { background:#666; color:#fff; }
 .awg-ac-list::-webkit-scrollbar { width:5px; }
 .awg-ac-list::-webkit-scrollbar-thumb { background:#888; border-radius:3px; }
+.awg-textarea {
+    width:95%;
+    min-height:78px;
+    resize:vertical;
+    font-family:monospace;
+    font-size:12px;
+}
 </style>
 <script>
 var custom_settings = <% get_custom_settings(); %>;
@@ -102,6 +109,16 @@ var v2flyList = [];
 var v2flyIpList = ['telegram','google','facebook','twitter','netflix','cloudflare','fastly','cloudfront'];
 function escHtml(s){
     return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+function normalizeListValue(value){
+    return String(value || '')
+        .split(/[\n,]+/)
+        .map(function(s){ return s.replace(/\s+/g, '').replace(/^\./, ''); })
+        .filter(function(s){ return s; })
+        .join(',');
+}
+function listToTextarea(value){
+    return String(value || '').split(',').map(function(s){ return s.trim(); }).filter(function(s){ return s; }).join('\n');
 }
 function loadV2flyCategories(){
     var xhr = new XMLHttpRequest();
@@ -279,6 +296,8 @@ function saveSettings(){
     custom_settings.awg_geo_v2fly_ip = document.getElementById('awg_geo_v2fly_ip').value;
     custom_settings.awg_geo_custom_domains = document.getElementById('geo_custom_domains').value;
     custom_settings.awg_geo_custom_ips = document.getElementById('geo_custom_ips').value;
+    custom_settings.awg_direct_custom_domains = normalizeListValue(document.getElementById('direct_custom_domains').value);
+    custom_settings.awg_direct_custom_ips = normalizeListValue(document.getElementById('direct_custom_ips').value);
     custom_settings.awg_geo_autoupdate = document.getElementById('geo_autoupdate').checked ? '1' : '0';
 
     // Basic validation
@@ -374,6 +393,11 @@ function loadGeoSettings(){
     if(cd) cd.value = custom_settings.awg_geo_custom_domains || '';
     var ci = document.getElementById('geo_custom_ips');
     if(ci) ci.value = custom_settings.awg_geo_custom_ips || '';
+    // Direct destination exceptions
+    var dd = document.getElementById('direct_custom_domains');
+    if(dd) dd.value = listToTextarea(custom_settings.awg_direct_custom_domains || '');
+    var di = document.getElementById('direct_custom_ips');
+    if(di) di.value = listToTextarea(custom_settings.awg_direct_custom_ips || '');
     // Auto-update
     var au = document.getElementById('geo_autoupdate');
     if(au) au.checked = (custom_settings.awg_geo_autoupdate === '1');
@@ -623,6 +647,8 @@ function updateStatusUI(s){
         if(s.active_rules > 0) infoParts.push(s.active_rules + ' routing rule(s)');
         if(s.ipset_count > 0) infoParts.push(s.ipset_count + ' IP ranges');
         if(s.geo_domains > 0) infoParts.push(s.geo_domains + ' domain rules');
+        if(s.direct_ipset_count > 0) infoParts.push(s.direct_ipset_count + ' direct IPs');
+        if(s.direct_domains > 0) infoParts.push(s.direct_domains + ' direct domains');
         rulesEl.innerHTML = infoParts.join(' &middot; ') || 'no rules active';
         rulesEl.style.color = '#93E7FF';
     } else {
@@ -1140,6 +1166,28 @@ function initAutocompleteIp(){
                 </table>
 
                 </div>
+
+                <!-- ==================== DIRECT EXCEPTIONS ==================== -->
+                <div class="awg-section">Direct Exceptions</div>
+                <table width="100%" border="1" cellpadding="4" cellspacing="0" class="FormTable" style="margin-top:8px;">
+                <thead><tr><td colspan="2">Bypass VPN for Destinations</td></tr></thead>
+                <tr>
+                    <th width="35%">Direct Domains</th>
+                    <td>
+                        <textarea class="input_32_table awg-textarea" id="direct_custom_domains"
+                                  placeholder="example.com&#10;another.org"></textarea>
+                        <div style="color:#666; font-size:11px; margin-top:3px;">One per line or comma-separated. DNS results are added to a direct ipset and bypass VPN.</div>
+                    </td>
+                </tr>
+                <tr>
+                    <th>Direct IPs / Subnets</th>
+                    <td>
+                        <textarea class="input_32_table awg-textarea" id="direct_custom_ips"
+                                  placeholder="203.0.113.10/32&#10;198.51.100.0/24"></textarea>
+                        <div style="color:#666; font-size:11px; margin-top:3px;">IPv4 addresses or CIDR ranges that should use WAN directly before VPN routing rules are evaluated.</div>
+                    </td>
+                </tr>
+                </table>
 
                 <!-- Apply -->
                 <div style="margin-top:12px; text-align:center;">

--- a/build-ipk.sh
+++ b/build-ipk.sh
@@ -11,6 +11,8 @@ cd "$SCRIPT_DIR"
 
 PKG_NAME="amneziawg"
 PKG_VERSION="1.1.6-1"
+TAR_BIN="${TAR_BIN:-$(command -v gtar || command -v tar)}"
+[ -z "$TAR_BIN" ] && { echo "ERROR: gtar or tar not found"; exit 1; }
 
 build_ipk(){
     local arch="$1"
@@ -98,7 +100,7 @@ PRERMEOF
     : > "$CONTROL_DIR/conffiles"
 
     cd "$CONTROL_DIR"
-    gtar czf "$WORK_DIR/control.tar.gz" --format=gnu ./control ./postinst ./prerm ./conffiles
+    "$TAR_BIN" czf "$WORK_DIR/control.tar.gz" --format=gnu ./control ./postinst ./prerm ./conffiles
     cd - > /dev/null
 
     # --- data tarball ---
@@ -144,13 +146,13 @@ INITEOF
     chmod 755 "$DATA_DIR/opt/etc/init.d/S99amneziawg"
 
     cd "$DATA_DIR"
-    gtar czf "$WORK_DIR/data.tar.gz" --format=gnu ./opt ./jffs
+    "$TAR_BIN" czf "$WORK_DIR/data.tar.gz" --format=gnu ./opt ./jffs
     cd - > /dev/null
 
     # --- Assemble .ipk (tar.gz format — Entware opkg uses tar.gz, not ar) ---
     cd "$WORK_DIR"
     mkdir -p "$SCRIPT_DIR/output"
-    gtar czf "$SCRIPT_DIR/output/$ipk_file" --format=gnu ./debian-binary ./data.tar.gz ./control.tar.gz
+    "$TAR_BIN" czf "$SCRIPT_DIR/output/$ipk_file" --format=gnu ./debian-binary ./data.tar.gz ./control.tar.gz
     cd "$SCRIPT_DIR"
 
     rm -rf "$WORK_DIR"


### PR DESCRIPTION
## What changed

- Add native Direct Exceptions for destination-based VPN bypass.
- Build a dedicated `awg_direct` ipset from custom IPv4/CIDR entries.
- Build a dedicated dnsmasq `ipset=/domain/awg_direct` config for direct domains.
- Insert the direct ipset RETURN rule before per-device/default VPN MARK rules.
- Expose Direct Domains and Direct IPs / Subnets in the Web UI.
- Include direct exception counters in status JSON/UI routing summary.
- Let `build-ipk.sh` use `gtar` or `tar` for easier local packaging.
- Document the new mode in English and Russian READMEs.

## Why

This supports the common AmneziaVPN split-tunneling mode: keep the router default as VPN All, but bypass VPN for selected destination domains and IP ranges.

## Validation

- `sh -n addon/amneziawg.sh`
- UI JavaScript parsed with Node after replacing the ASUS template variable.
- Built `output/amneziawg_1.1.6-1_armv7-3.2.ipk` using release binaries for RT-AX58U.
- Deployed the updated addon backend/UI to an ASUS RT-AX58U running ASUSWRT-Merlin.
- Imported 222 IPv4/CIDR and 62 domain exceptions from desktop AmneziaVPN `ExceptSites`.
- Verified normal client traffic still exits through VPN IP `91.247.37.143`.
- Verified excluded destination `samaraenergo.ru` resolves to `89.104.80.220`, lands in `awg_direct`, and routes via WAN (`eth4`) instead of `awg0`.
- Verified `firewall_restart` reapplies direct exception rules.

## Notes

IPv6 direct exceptions are intentionally not applied while the addon IPv6 leak protection blocks IPv6 forwarding through the VPN path.
